### PR TITLE
Combined dependency updates (2024-01-03)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-slf4j2-impl</artifactId>
-				<version>2.22.0</version>
+				<version>2.22.1</version>
 				<scope>test</scope>
 			</dependency>
 			

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>2.0.9</version>
+				<version>2.0.10</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.7.0</version>
+				<version>42.7.1</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.22.0 to 2.22.1](https://github.com/javiertuya/samples-db-containers/pull/12)
- [Bump org.postgresql:postgresql from 42.7.0 to 42.7.1](https://github.com/javiertuya/samples-db-containers/pull/10)
- [Bump org.slf4j:slf4j-api from 2.0.9 to 2.0.10](https://github.com/javiertuya/samples-db-containers/pull/11)