### PR TITLE
Combined dependency updates (2025-02-03)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.7.4</version>
+				<version>42.7.5</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.postgresql:postgresql from 42.7.4 to 42.7.5](https://github.com/javiertuya/samples-db-containers/pull/43)