### PR TITLE
Combined dependency updates (2025-04-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 			<dependency>
 				<groupId>com.microsoft.sqlserver</groupId>
 				<artifactId>mssql-jdbc</artifactId>
-				<version>12.9.0.jre8-preview</version>
+				<version>12.10.0.jre8</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.microsoft.sqlserver:mssql-jdbc from 12.9.0.jre8-preview to 12.10.0.jre8](https://github.com/javiertuya/samples-db-containers/pull/48)