### PR TITLE
Combined dependency updates (2025-06-07)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 			<dependency>
 				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc8</artifactId>
-				<version>23.7.0.25.01</version>
+				<version>23.8.0.25.04</version>
 				<scope>test</scope>
 			</dependency>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.oracle.database.jdbc:ojdbc8 from 23.7.0.25.01 to 23.8.0.25.04](https://github.com/javiertuya/samples-db-containers/pull/51)
- [Bump org.postgresql:postgresql from 42.7.5 to 42.7.6](https://github.com/javiertuya/samples-db-containers/pull/50)