### PR TITLE
Combined dependency updates (2025-09-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         dbms: [Postgres, Oracle, Sqlserver]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Select Java Version
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 			<dependency>
 				<groupId>com.microsoft.sqlserver</groupId>
 				<artifactId>mssql-jdbc</artifactId>
-				<version>12.10.0.jre8</version>
+				<version>13.2.0.jre8</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/checkout from 4 to 5](https://github.com/javiertuya/samples-db-containers/pull/61)
- [Bump actions/setup-java from 4 to 5](https://github.com/javiertuya/samples-db-containers/pull/63)
- [Bump com.microsoft.sqlserver:mssql-jdbc from 12.10.0.jre8 to 13.2.0.jre8](https://github.com/javiertuya/samples-db-containers/pull/62)