### PR TITLE
Combined dependency updates (2026-03-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.7.9</version>
+				<version>42.7.10</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 			<dependency>
 				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc8</artifactId>
-				<version>23.26.0.0.0</version>
+				<version>23.26.1.0.0</version>
 				<scope>test</scope>
 			</dependency>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.oracle.database.jdbc:ojdbc8 from 23.26.0.0.0 to 23.26.1.0.0](https://github.com/javiertuya/samples-db-containers/pull/84)
- [Bump org.postgresql:postgresql from 42.7.9 to 42.7.10](https://github.com/javiertuya/samples-db-containers/pull/83)