### PR TITLE
Combined dependency updates (2026-04-05)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 			<dependency>
 				<groupId>com.microsoft.sqlserver</groupId>
 				<artifactId>mssql-jdbc</artifactId>
-				<version>13.2.1.jre8</version>
+				<version>13.4.0.jre8</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-slf4j2-impl</artifactId>
-				<version>2.25.3</version>
+				<version>2.25.4</version>
 				<scope>test</scope>
 			</dependency>
 			


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.microsoft.sqlserver:mssql-jdbc from 13.2.1.jre8 to 13.4.0.jre8](https://github.com/javiertuya/samples-db-containers/pull/87)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.25.3 to 2.25.4](https://github.com/javiertuya/samples-db-containers/pull/86)