### PR TITLE
Combined dependency updates (2026-05-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.7.10</version>
+				<version>42.7.11</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.postgresql:postgresql from 42.7.10 to 42.7.11](https://github.com/javiertuya/samples-db-containers/pull/89)