### PR TITLE
Combined dependency updates (2026-06-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-slf4j2-impl</artifactId>
-				<version>2.25.4</version>
+				<version>2.26.0</version>
 				<scope>test</scope>
 			</dependency>
 			

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 			<dependency>
 				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc8</artifactId>
-				<version>23.26.1.0.0</version>
+				<version>23.26.2.0.0</version>
 				<scope>test</scope>
 			</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>2.0.17</version>
+				<version>2.0.18</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.oracle.database.jdbc:ojdbc8 from 23.26.1.0.0 to 23.26.2.0.0](https://github.com/javiertuya/samples-db-containers/pull/93)
- [Bump org.slf4j:slf4j-api from 2.0.17 to 2.0.18](https://github.com/javiertuya/samples-db-containers/pull/92)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.25.4 to 2.26.0](https://github.com/javiertuya/samples-db-containers/pull/91)