### PR TITLE
Combined dependency updates (2026-07-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         dbms: [Postgres, Oracle, Sqlserver]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.7.11</version>
+				<version>42.7.12</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.postgresql:postgresql from 42.7.11 to 42.7.12](https://github.com/javiertuya/samples-db-containers/pull/96)
- [Bump actions/checkout from 6 to 7](https://github.com/javiertuya/samples-db-containers/pull/95)